### PR TITLE
Support for customizable Fedora namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,13 @@ pip install git+https://github.com/CESNET/fedoralink.git
 django-admin startproject testfedora
 ```
 
-### 2. Add fedoralink and testfedora into INSTALLED_APPS in settings.py:
+### 2. Add fedoralink into INSTALLED_APPS in settings.py:
 ```python
 INSTALLED_APPS += [
     'fedoralink',
-    'testfedora'
 ]
 ```
-### 3. Add repository/ies and database router into settings.py:
+### 3. Add repository/ies into settings.py:
 ```python
 DATABASES['repository'] = {
     'ENGINE'            : 'fedoralink.db',
@@ -43,7 +42,13 @@ DATABASE_ROUTERS = [
 ]
 ```
 
-### 4. To test:
+### 4. Specify a path to the Fedora Namespaces config file in settings.py:
+```python
+FEDORA_NODE_TYPES = '/etc/fcrepo/fedora-node-types.cnd'
+```
+
+
+### 5. To test:
 
 bash:
 ```bash
@@ -65,7 +70,7 @@ FedoraObject.objects.filter(fedora_id='')
 
 ```
 
-### 5. Simple operations
+### 6. Simple operations
 
 #### Create and save a fedora object
 

--- a/fedoralink/fedorans.py
+++ b/fedoralink/fedorans.py
@@ -1,53 +1,40 @@
 from rdflib import Namespace, URIRef
+from os.path import abspath
+from django.conf import settings
+from django.core.cache import cache
 
-NAMESPACES = {
-            "premis"        :   "http://www.loc.gov/premis/rdf/v1#",
-            "image"         :   "http://www.modeshape.org/images/1.0",
-            "sv"            :   "http://www.jcp.org/jcr/sv/1.0",
-            "test"          :   "info:fedora/test/",
-            "nt"            :   "http://www.jcp.org/jcr/nt/1.0",
-            "rdfs"          :   "http://www.w3.org/2000/01/rdf-schema#",
-            "xsi"           :   "http://www.w3.org/2001/XMLSchema-instance",
-            "mode"          :   "http://www.modeshape.org/1.0",
-            "rdf"           :   "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-            "fedora"        :   "http://fedora.info/definitions/v4/repository#",
-            "fedora_index"  :   "http://fedora.info/definitions/v4/indexing#",
-            "xml"           :   "http://www.w3.org/XML/1998/namespace",
-            "ebucore"       :   "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#",
-            "ldp"           :   "http://www.w3.org/ns/ldp#",
-            "xs"            :   "http://www.w3.org/2001/XMLSchema",
-            "fedoraconfig"  :   "http://fedora.info/definitions/v4/config#",
-            "mix"           :   "http://www.jcp.org/jcr/mix/1.0",
-            "foaf"          :   "http://xmlns.com/foaf/0.1/",
-            "dc"            :   "http://purl.org/dc/elements/1.1/",
-            "dcterms"       :   "http://purl.org/dc/terms/",
-            "cis"           :   "http://cis.vscht.cz/ns/repository#",
-            "cesnet"        :   "http://cesnet.cz/ns/repository#",
-            "cesnet_state"  :   "http://cesnet.cz/ns/repository/state#",
-            "cesnet_type"  :   "http://cesnet.cz/ns/repository/type#",
-            "acl"           :   "http://www.w3.org/ns/auth/acl#"
-}
 
-FEDORA          =   Namespace(NAMESPACES['fedora'])
-FEDORA_INDEX    =   Namespace(NAMESPACES['fedora_index'])
+NAMESPACES = cache.get('NAMESPACES')
+
+if not NAMESPACES:
+    NAMESPACES = {}
+    with open(abspath(settings.FEDORA_NODE_TYPES), 'r') as fedoraNodeTypesConf:
+        for line in fedoraNodeTypesConf:
+            if line.startswith('<') and '=' in line:
+                name, url = line.lstrip('<').replace('>','').replace("'", '').replace(' ', '').strip().split('=', 1)
+                if 'http' not in url:
+                    continue
+                NAMESPACES[name] = url
+    cache.set('NAMESPACES', NAMESPACES, 3600)
+
+FEDORA          =   Namespace(NAMESPACES['fedora']) if 'fedora' in NAMESPACES else None
 FEDORA_CREATED_METADATA = URIRef(FEDORA.created)
 FEDORA_LAST_MODIFIED_BY_METADATA = URIRef(FEDORA.lastModifiedBy)
 FEDORA_PRIMARY_TYPE_METADATA = URIRef(FEDORA.primaryType)
 FEDORA_MIXIN_TYPES_METADATA = URIRef(FEDORA.mixinTypes)
 FEDORA_LAST_MODIFIED_METADATA = URIRef(FEDORA.lastModified)
 
-RDF             =   Namespace(NAMESPACES['rdf'])
-RDFS            =   Namespace(NAMESPACES['rdfs'])
-LDP             =   Namespace(NAMESPACES['ldp'])
+RDF             =   Namespace(NAMESPACES['rdf']) if 'rdf' in NAMESPACES else None
+RDFS            =   Namespace(NAMESPACES['rdfs']) if 'rdfs' in NAMESPACES else None
+LDP             =   Namespace(NAMESPACES['ldp']) if 'ldp' in NAMESPACES else None
 
-EBUCORE         =   Namespace(NAMESPACES['ebucore'])
-PREMIS          =   Namespace(NAMESPACES['premis'])
+EBUCORE         =   Namespace(NAMESPACES['ebucore']) if 'ebucore' in NAMESPACES else None
+PREMIS          =   Namespace(NAMESPACES['premis']) if 'premis' in NAMESPACES else None
 
-CIS             =   Namespace(NAMESPACES['cis'])
-CESNET          =   Namespace(NAMESPACES['cesnet'])
-CESNET_STATE    =   Namespace(NAMESPACES['cesnet_state'])
-CESNET_TYPE     =   Namespace(NAMESPACES['cesnet_type'])
-ACL             =   Namespace(NAMESPACES['acl'])
+CESNET          =   Namespace(NAMESPACES['cesnet']) if 'cesnet' in NAMESPACES else None
+CESNET_STATE    =   Namespace(NAMESPACES['cesnet_state']) if 'cesnet_state' in NAMESPACES else None
+CESNET_TYPE     =   Namespace(NAMESPACES['cesnet_type']) if 'cesnet_type' in NAMESPACES else None
+ACL             =   Namespace(NAMESPACES['acl']) if 'acl' in NAMESPACES else None
 
 
 


### PR DESCRIPTION
This pull request replaces the hardcoded Fedora namespaces with the ones defined by an user in a config file fedora-node-types.cnd (which is also parsed and used directly by Fedora). Namespaces loaded from the config file are cached and refreshed each hour. 